### PR TITLE
Add the animation post load instead of before to reduce flash

### DIFF
--- a/theme/book.js
+++ b/theme/book.js
@@ -462,6 +462,9 @@ function playground_text(playground, hidden = true) {
     }
   });
 
+  // Don't animate until we have loaded so we don't get flash
+  document.getElementById("body-container").style.transition = "all 300ms";
+
   sidebarResizeHandle.addEventListener("mousedown", initResize, false);
 
   function initResize(e) {

--- a/theme/css/chrome.css
+++ b/theme/css/chrome.css
@@ -82,7 +82,6 @@ a > .hljs {
         will want to reposition the viewport in a weird way.
     */
   overflow-x: clip;
-  transition: 200ms;
 }
 
 /* Menu Bar */


### PR DESCRIPTION
When the sidebar was animating on the initial load, it would flash animate. This way the animation is applied after the first render.