### PR TITLE
Core -> Whitepaper

### DIFF
--- a/.spellcheckerdict.txt
+++ b/.spellcheckerdict.txt
@@ -208,3 +208,4 @@ TBD
 precalculated
 unfollowing
 [Ww]ebhook(s?)
+[Ww]hitepaper

--- a/book.toml
+++ b/book.toml
@@ -34,6 +34,9 @@ additional-css = [
   "css/highlight-dark.css",
 ]
 
+[output.html.redirect]
+"/Core.html" = "/Whitepaper.html"
+
 # https://github.com/Michael-F-Bryan/mdbook-linkcheck
 # [output.linkcheck]
 # exclude = [

--- a/pages/SUMMARY.md
+++ b/pages/SUMMARY.md
@@ -4,7 +4,7 @@
 - [Become a Provider](Guides/BecomeAProvider.md)
 - [Frequency Developer Gateway](Guides/Gateway.md)
 - [Add Single Sign-On to your App](Guides/SSO.md)
-- [Core](Core.md)
+- [Whitepaper](Whitepaper.md)
     - [Architecture](Architecture/index.md)
         - [Operational Model](Architecture/OperationalModel.md)
         - [Interaction Model](Architecture/InteractionModel.md)

--- a/pages/Whitepaper.md
+++ b/pages/Whitepaper.md
@@ -1,6 +1,6 @@
-{{#title-image .04 pages/images/icons/house.svg "Frequency Core"}}
+{{#title-image .04 pages/images/icons/house.svg "Frequency Whitepaper"}}
 
-# Frequency Core
+# Frequency Whitepaper
 
 Frequency is a purpose-built Layer 1 public blockchain designed to fulfill the promise of the [Decentralized Social Networking Protocol (DSNP)](https://www.dsnp.org).
 Frequency delivers essential infrastructure to create the next generation of social networking apps that give individuals more control over their data and agency to participate in the evolving digital economy.


### PR DESCRIPTION
Rename Core to Whitepaper & add redirect

## Testing

- `mdbook serve`
- Make sure Whitepaper is shown instead of Core
- Make sure /Core.html redirects to the Whitepaper