### PR TITLE
fix typo, pin package versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,13 +20,13 @@
   },
   "devDependencies": {
     "@frequency-chain/style-guide": "v0.4.1",
-    "@tailwindcss/cli": "^4.1.7",
-    "remark": "^15.0.1",
-    "remark-cli": "^12.0.1",
-    "remark-lint": "^10.0.1",
-    "remark-preset-lint-recommended": "^7.0.1",
-    "spellchecker-cli": "^7.0.0",
-    "tailwindcss": "^4.1.7"
+    "@tailwindcss/cli": "4.1.7",
+    "remark": "15.0.1",
+    "remark-cli": "12.0.1",
+    "remark-lint": "10.0.1",
+    "remark-preset-lint-recommended": "7.0.1",
+    "spellchecker-cli": "7.0.1  ",
+    "tailwindcss": "4.1.7"
   },
   "engines": {
     "node": ">=20"

--- a/pages/index.md
+++ b/pages/index.md
@@ -19,7 +19,7 @@ Whether you're a beginner or an experienced developer, our resources will guide 
     <a href="./Guides/SSO.md">
     Single Sign-on
   </a>
-    <a href="./Whitepaper.m">
+    <a href="./Whitepaper.md">
     Frequency Whitepaper
   </a>
 </div>


### PR DESCRIPTION
Problem
=======
A typo in the link to the white paper caused a broken link.

Original report from @jeanettedepatie 
> On the bottom of the page https://docs.frequency.xyz/, if you go to the bottom and click the oval button labeled frequency white paper, it leads to a 404 page…

Solution
========
Add a 'd'

Also pin package versions.  This had no effect on package-lock.json

Steps to Verify:
----------------
1. mdbook build
1. mdbook serve
1. go to the local server, follow the original report instructions
1. Verify the link is not 404, but displays the content at Whitepaper.html

Screenshots (optional):
-----------------------

https://github.com/user-attachments/assets/99fee15e-969e-4dfb-bb79-211cfd872bdd

